### PR TITLE
Allow raw numbers as scalars without explicit `as_tensor` conversion.

### DIFF
--- a/examples/predictive.md
+++ b/examples/predictive.md
@@ -68,7 +68,7 @@ Having optimized the variational approximation, we draw posterior samples and vi
 # Draw posterior samples and broadcast them over the model to get predictions.
 samples = approximation().sample([100])
 
-nlin = torch.as_tensor(101)
+nlin = 101
 lin = torch.linspace(state["x"].min() - 0.1, state["x"].max() + 0.1, nlin)
 predictions = mininf.broadcast_samples(mininf.condition(model, n=nlin, x=lin), samples)
 

--- a/examples/regression-with-feature-uncertainty.md
+++ b/examples/regression-with-feature-uncertainty.md
@@ -69,9 +69,9 @@ We have defined a model and generated synthetic data. To recover the parameters 
 ```{code-cell} ipython3
 approximation = nn.ParameterizedFactorizedDistribution(
     z=nn.ParameterizedDistribution(Normal, loc=torch.zeros(n), scale=torch.ones(n)),
-    intercept=nn.ParameterizedDistribution(Normal, loc=0, scale=1),
-    slope=nn.ParameterizedDistribution(Normal, loc=0, scale=1),
-    population_scale=nn.ParameterizedDistribution(Gamma, concentration=2, rate=2),
+    intercept=nn.ParameterizedDistribution(Normal, loc=0.0, scale=1.0),
+    slope=nn.ParameterizedDistribution(Normal, loc=0.0, scale=1.0),
+    population_scale=nn.ParameterizedDistribution(Gamma, concentration=2.0, rate=2.0),
 )
 approximation()
 ```

--- a/mininf/util.py
+++ b/mininf/util.py
@@ -1,3 +1,4 @@
+import numbers
 import torch
 from torch.distributions.constraints import Constraint
 from typing import Any, Dict, TypeVar
@@ -81,3 +82,18 @@ def get_masked_data_with_dense_grad(value: torch.masked.MaskedTensor) -> torch.T
             return torch.where(value._masked_mask, grad_output, 0)
 
     return GetData.apply(value)
+
+
+def maybe_as_tensor(value: Any) -> torch.Tensor | None:
+    """
+    Return a value as a tensor if it is convertible, allowing for raw numbers.
+
+    Args:
+        value: Value to convert to a tensor.
+
+    Returns:
+        Value as a tensor.
+    """
+    if value is not None and isinstance(value, numbers.Number):
+        value = torch.as_tensor(value)
+    return value

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -105,7 +105,7 @@ def test_condition() -> None:
         mininf.sample("y", torch.distributions.Gamma(2, 2), (3,))
         return x
 
-    conditioned = mininf.condition(model, x=torch.as_tensor(0.3))
+    conditioned = mininf.condition(model, x=0.3)
 
     with mininf.State() as state1:
         conditioned()
@@ -121,12 +121,12 @@ def test_condition() -> None:
         model()
     assert abs(state["x"] - 0.3) > 1e-6
 
-    assert mininf.condition(model, x=torch.as_tensor(0.25))() == 0.25
+    assert mininf.condition(model, x=0.25)() == 0.25
 
     # Test conditioning with dictionaries and ensure precedence is right to left.
-    subset = {"x": torch.as_tensor(0.1)}
+    subset = {"x": 0.1}
     assert mininf.condition(model, subset)() == 0.1
-    assert mininf.condition(model, subset, x=torch.as_tensor(0.7))() == 0.7
+    assert mininf.condition(model, subset, x=0.7)() == 0.7
 
 
 def test_validate_sample() -> None:
@@ -183,10 +183,10 @@ def test_condition_conflict(strict: bool) -> None:
     def model() -> None:
         return mininf.sample("x", torch.distributions.Normal(0, 1))
 
-    conditioned1 = mininf.condition(model, x=torch.as_tensor(0.1), _strict=strict)
+    conditioned1 = mininf.condition(model, x=0.1, _strict=strict)
     assert conditioned1() == 0.1
 
-    conditioned2 = mininf.condition(conditioned1, x=torch.as_tensor(0.7))
+    conditioned2 = mininf.condition(conditioned1, x=0.7)
     if strict:
         with pytest.raises(ValueError, match="Cannot update"):
             conditioned2()
@@ -247,7 +247,7 @@ def test_value_without_default_or_shape() -> None:
     with pytest.raises(ValueError, match="No default value given."):
         model()
 
-    assert mininf.condition(model, x=torch.as_tensor(3))() == 3
+    assert mininf.condition(model, x=3)() == 3
 
     with pytest.raises(ValueError, match=r"Expected shape \(\) for parameter"):
         mininf.condition(model, x=torch.randn(3))()
@@ -303,7 +303,7 @@ def test_value_support() -> None:
         mininf.value("x", support=constraints.nonnegative)
 
     with pytest.raises(ValueError, match=r"is not in the support of Value\(shape="):
-        mininf.condition(model, x=torch.as_tensor(-2))()
+        mininf.condition(model, x=-2)()
 
 
 def test_broadcast_samples():
@@ -314,7 +314,7 @@ def test_broadcast_samples():
         mininf.value("y", x + a)
 
     x = torch.randn(7)
-    states = mininf.broadcast_samples(mininf.condition(model, a=torch.as_tensor(1.3)), x=x)
+    states = mininf.broadcast_samples(mininf.condition(model, a=1.3), x=x)
     torch.testing.assert_close(states["y"], x + 1.3)
 
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -10,7 +10,7 @@ from typing import Set, Type
 
 
 @pytest.mark.parametrize("cls, params, _const, grads", [
-    (distributions.Normal, {"loc": 0, "scale": 1}, set(), {"loc", "scale"}),
+    (distributions.Normal, {"loc": 0.0, "scale": 1.0}, set(), {"loc", "scale"}),
     (distributions.Normal, {"loc": torch.randn(3), "scale": torch.ones(2, 1)}, {"loc"}, {"scale"}),
     (distributions.LKJCholesky, {"dim": 3, "concentration": 9}, set(), {"concentration"}),
 ])
@@ -51,7 +51,7 @@ def test_evidence_lower_bound_loss_with_grad() -> None:
     def model() -> None:
         mininf.sample("x", torch.distributions.Normal(0, 1), (3,))
 
-    approximation = ParameterizedDistribution(torch.distributions.Normal, loc=0,
+    approximation = ParameterizedDistribution(torch.distributions.Normal, loc=0.0,
                                               scale=torch.ones(3))
     loss = EvidenceLowerBoundLoss()
     loss_value = loss(model, {"x": approximation()})
@@ -74,7 +74,7 @@ def test_evidence_lower_bound_wrong_distribution_type() -> None:
 
 def test_parameterized_distribution_no_exposed_parameters() -> None:
     # Check that parameters are not directly exposed.
-    approximation = ParameterizedDistribution(torch.distributions.Normal, loc=0, scale=1)
+    approximation = ParameterizedDistribution(torch.distributions.Normal, loc=0.0, scale=1.0)
     distribution = approximation()
     assert not isinstance(distribution.loc, torch.nn.Parameter)
     assert not isinstance(distribution.scale, torch.nn.Parameter)
@@ -103,8 +103,8 @@ def test_parameterized_distribution_input_cloned(clone: bool) -> None:
 
 def test_factorized_parameterized_distribution() -> None:
     module = ParameterizedFactorizedDistribution(
-        {"a": ParameterizedDistribution(torch.distributions.Normal, loc=0, scale=1)},
-        b=ParameterizedDistribution(torch.distributions.Gamma, concentration=3, rate=2),
+        {"a": ParameterizedDistribution(torch.distributions.Normal, loc=0.0, scale=1.0)},
+        b=ParameterizedDistribution(torch.distributions.Gamma, concentration=3.0, rate=2.0),
     )
     assert set(module) == {"a", "b"}
     assert isinstance(module()["a"], torch.distributions.Normal)


### PR DESCRIPTION
☝️ 